### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd swapseed
 2. Install the required dependencies:
 
 ```pip
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 3. Execution


### PR DESCRIPTION
The command `pip install requirements.txt` fails. 

It needs to be `pip install -r requirements.txt`. 

Updating the instructions to avoid confusion for learners.